### PR TITLE
Add frozen finance training mode

### DIFF
--- a/logger.py
+++ b/logger.py
@@ -61,7 +61,14 @@ class TBLogger:
 
         avg = {k: float(np.mean([r[k] for r in results])) for k in results[0]}
         for k, v in avg.items():
-            tag = f"trading/{k.replace(' ', '_')}"     # TB tags can’t have spaces
+            safe_key = (
+                k.replace(" ", "_")
+                .replace("/", "_")
+                .replace("%", "pct")
+                .replace("(", "_")
+                .replace(")", "_")
+            )
+            tag = f"trading/{safe_key}"
             self.writer.add_scalar(tag, v, epoch)
 
     # ─────────────────────────── housekeeping ───────────────────── #

--- a/trade.py
+++ b/trade.py
@@ -66,24 +66,25 @@ def trading(
     sharpe = daily_ret.mean() / daily_ret.std() if daily_ret.std() else 0
 
     total_days = max((timestamps[-1] - timestamps[0]).days, 1)
-    ann_return = safe_cagr(final_value, initial_fund, total_days)       # ✔ no overflow
+    ann_return = safe_cagr(final_value, initial_fund, total_days)  # ✔ no overflow
 
-    trade_pcts  = [t["profit_pct"] for t in trades]
-    idle_ratio  = predictions.count(0) / len(predictions) * 100
+    trade_pcts = [t["profit_pct"] for t in trades]
+    idle_ratio = predictions.count(0) / len(predictions) * 100
 
     result = {
         "Final Value": final_value,
         "Buy & Hold": buy_hold,
-        "Annualized Return (%)": ann_return,
+        "CAGR (%)": ann_return,
         "Sharpe Ratio (daily)": sharpe,
         "Trades Performed": len(trades),
         "Trades Won": sum(p > 0 for p in trade_pcts),
-        "Percent of Success": (sum(p > 0 for p in trade_pcts) / len(trades) * 100) if trades else 0,
-        "Avg Profit per Trade (%)": np.mean(trade_pcts) if trades else 0,
+        "Win Rate (%)": (sum(p > 0 for p in trade_pcts) / len(trades) * 100) if trades else 0,
+        "Avg Profit/Trade (%)": np.mean(trade_pcts) if trades else 0,
         "Avg Trade Length (days)": np.mean([t["length"] for t in trades]) if trades else 0,
         "Max Profit/Trade (%)": max(trade_pcts, default=0),
         "Max Loss/Trade (%)": min(trade_pcts, default=0),
         "Idle Ratio (%)": idle_ratio,
+        "Period (days)": total_days,
     }
     return result, pd.DataFrame(trades)
 

--- a/train_multimodal.py
+++ b/train_multimodal.py
@@ -17,22 +17,26 @@ device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
 
 # ───────── training loop ───────────
-def train():
-    model = config.model(in_channels=2).to(device)
+def _run_training(in_channels: int, include_sentiment: bool, log_suffix: str, comment: str):
+    model = config.model(in_channels=in_channels).to(device)
     opt = torch.optim.Adam(model.parameters(), lr=config.learning_rate)
     crit = torch.nn.CrossEntropyLoss(weight=torch.tensor(config.class_weights, device=device))
 
-    finance_train_dir = list(Path(config.train_dir).glob(config.sentiment_ticker + "*.csv"))[0].__str__()
-    finance_test_dir = list(Path(config.test_dir).glob(config.sentiment_ticker + "*.csv"))[0].__str__()
+    finance_train_dir = list(Path(config.train_dir).glob(config.sentiment_ticker + "*.csv"))[0]
+    finance_test_dir = list(Path(config.test_dir).glob(config.sentiment_ticker + "*.csv"))[0]
 
-    # ---- data ----
-    train_ds = MultiModalDataset(str(finance_train_dir), config.sentiment_dir, config.indicators)
-    train_ld = DataLoader(train_ds, batch_size=config.batch_size, shuffle=True, pin_memory=True, drop_last=True)
+    train_ds = MultiModalDataset(str(finance_train_dir), config.sentiment_dir,
+                                config.indicators, include_sentiment=include_sentiment)
+    train_ld = DataLoader(train_ds, batch_size=config.batch_size, shuffle=True,
+                          pin_memory=True, drop_last=True)
 
-    test_ds = MultiModalDataset(str(finance_test_dir), config.sentiment_dir, config.indicators)
-    test_ld = DataLoader(test_ds, batch_size=config.batch_size, shuffle=False, pin_memory=True)
+    test_ds = MultiModalDataset(str(finance_test_dir), config.sentiment_dir,
+                               config.indicators, include_sentiment=include_sentiment)
+    test_ld = DataLoader(test_ds, batch_size=config.batch_size, shuffle=False,
+                         pin_memory=True)
 
-    logger = TBLogger(config.record_dir, config.run_name, comment="MultiModal")
+    run_name = f"{config.run_name}_{log_suffix}"
+    logger = TBLogger(config.record_dir, run_name, comment=comment)
 
     for epoch in trange(config.max_epochs, desc="Epochs"):
         # =================== TRAIN =================== #
@@ -72,7 +76,7 @@ def train():
                 preds = torch.argmax(outs, 1).cpu().tolist()
                 labs = torch.argmax(lbls, 1).cpu().tolist()
 
-                p_all.extend(preds);
+                p_all.extend(preds)
                 y_all.extend(labs)
 
                 bucket = by_symbol.setdefault(config.sentiment_ticker, {"ts": [], "cl": [], "pr": []})
@@ -83,12 +87,139 @@ def train():
         logger.log_epoch("eval", epoch, tot_loss / batches,
                          np.array(y_all), np.array(p_all))
 
-        # ---- trading sim per symbol ----
         trade_res = [trading(v["ts"], v["cl"], v["pr"])[0]
                      for v in by_symbol.values()]
         logger.log_trading(epoch, trade_res)
 
     logger.close()
+
+
+def _run_finance_then_freeze(log_suffix: str, comment: str) -> None:
+    """Train a 2-channel model, first on finance only then freeze finance
+    convolution weights and continue training with sentiment."""
+
+    model = config.model(in_channels=2).to(device)
+    crit = torch.nn.CrossEntropyLoss(weight=torch.tensor(config.class_weights, device=device))
+
+    finance_train_dir = list(Path(config.train_dir).glob(config.sentiment_ticker + "*.csv"))[0]
+    finance_test_dir = list(Path(config.test_dir).glob(config.sentiment_ticker + "*.csv"))[0]
+
+    train_ds = MultiModalDataset(str(finance_train_dir), config.sentiment_dir,
+                                config.indicators, include_sentiment=True)
+    train_ld = DataLoader(train_ds, batch_size=config.batch_size, shuffle=True,
+                          pin_memory=True, drop_last=True)
+
+    test_ds = MultiModalDataset(str(finance_test_dir), config.sentiment_dir,
+                               config.indicators, include_sentiment=True)
+    test_ld = DataLoader(test_ds, batch_size=config.batch_size, shuffle=False,
+                         pin_memory=True)
+
+    run_name = f"{config.run_name}_{log_suffix}"
+    logger = TBLogger(config.record_dir, run_name, comment=comment)
+
+    # ── Stage A: train using only finance channel ─────────────────
+    opt = torch.optim.Adam(model.parameters(), lr=config.learning_rate)
+    for epoch in trange(config.max_epochs, desc="Fin only"):
+        model.train()
+        ep_loss, p_all, y_all = 0.0, [], []
+        for _, _, imgs, lbls in tqdm(train_ld, desc="Train", leave=False):
+            imgs[:, 1] = 0  # zero-out sentiment channel
+            imgs, lbls = imgs.to(device, non_blocking=True), lbls.to(device, non_blocking=True)
+
+            opt.zero_grad(set_to_none=True)
+            outs = model(imgs)
+            loss = crit(outs, lbls)
+            loss.backward()
+            opt.step()
+
+            ep_loss += loss.item()
+            p_all.extend(torch.argmax(outs, 1).cpu().tolist())
+            y_all.extend(torch.argmax(lbls, 1).cpu().tolist())
+
+        logger.log_epoch("train", epoch, ep_loss / len(train_ld), np.array(y_all), np.array(p_all))
+
+        # ---- eval ----
+        model.eval()
+        tot_loss, batches = 0.0, 0
+        p_all, y_all = [], []
+        by_symbol = {}
+        with torch.no_grad():
+            for ts, closes, imgs, lbls in tqdm(test_ld, desc="Eval", leave=False):
+                imgs[:, 1] = 0
+                imgs, lbls = imgs.to(device), lbls.to(device)
+                outs = model(imgs)
+                tot_loss += crit(outs, lbls).item(); batches += 1
+                preds = torch.argmax(outs, 1).cpu().tolist(); labs = torch.argmax(lbls, 1).cpu().tolist()
+                p_all.extend(preds); y_all.extend(labs)
+                bucket = by_symbol.setdefault(config.sentiment_ticker, {"ts": [], "cl": [], "pr": []})
+                bucket["ts"].extend(ts.cpu().tolist())
+                bucket["cl"].extend(closes.cpu().tolist())
+                bucket["pr"].extend(preds)
+
+        logger.log_epoch("eval", epoch, tot_loss / batches, np.array(y_all), np.array(p_all))
+        trade_res = [trading(v["ts"], v["cl"], v["pr"])[0] for v in by_symbol.values()]
+        logger.log_trading(epoch, trade_res)
+
+    # ── freeze finance channel weights ─────────────────────────────
+    def zero_finance_grad(grad):
+        grad[:, 0] = 0
+        return grad
+
+    model.conv1.weight.register_hook(zero_finance_grad)
+    model.conv1.bias.requires_grad_(False)
+
+    # new optimizer for unfrozen params only
+    opt = torch.optim.Adam(filter(lambda p: p.requires_grad, model.parameters()), lr=config.learning_rate)
+
+    # ── Stage B: train with sentiment channel ─────────────────────
+    for epoch in trange(config.max_epochs, desc="Fin frozen"):
+        model.train(); ep_loss, p_all, y_all = 0.0, [], []
+        for _, _, imgs, lbls in tqdm(train_ld, desc="Train", leave=False):
+            imgs, lbls = imgs.to(device, non_blocking=True), lbls.to(device, non_blocking=True)
+
+            opt.zero_grad(set_to_none=True)
+            outs = model(imgs)
+            loss = crit(outs, lbls)
+            loss.backward()
+            opt.step()
+
+            ep_loss += loss.item()
+            p_all.extend(torch.argmax(outs, 1).cpu().tolist())
+            y_all.extend(torch.argmax(lbls, 1).cpu().tolist())
+
+        offset = config.max_epochs + epoch
+        logger.log_epoch("train", offset, ep_loss / len(train_ld), np.array(y_all), np.array(p_all))
+
+        # ---- eval ----
+        model.eval(); tot_loss, batches = 0.0, 0; p_all, y_all = [], []; by_symbol = {}
+        with torch.no_grad():
+            for ts, closes, imgs, lbls in tqdm(test_ld, desc="Eval", leave=False):
+                imgs, lbls = imgs.to(device), lbls.to(device)
+                outs = model(imgs)
+                tot_loss += crit(outs, lbls).item(); batches += 1
+                preds = torch.argmax(outs, 1).cpu().tolist(); labs = torch.argmax(lbls, 1).cpu().tolist()
+                p_all.extend(preds); y_all.extend(labs)
+                bucket = by_symbol.setdefault(config.sentiment_ticker, {"ts": [], "cl": [], "pr": []})
+                bucket["ts"].extend(ts.cpu().tolist()); bucket["cl"].extend(closes.cpu().tolist()); bucket["pr"].extend(preds)
+
+        logger.log_epoch("eval", offset, tot_loss / batches, np.array(y_all), np.array(p_all))
+        trade_res = [trading(v["ts"], v["cl"], v["pr"])[0] for v in by_symbol.values()]
+        logger.log_trading(offset, trade_res)
+
+    logger.close()
+
+
+def train():
+    # ---- Stage 1: finance-only training ----
+    _run_training(in_channels=1, include_sentiment=False,
+                  log_suffix="finance_only", comment="finance-only")
+
+    # ---- Stage 2: full multimodal training ----
+    _run_training(in_channels=2, include_sentiment=True,
+                  log_suffix="multimodal", comment="multi-modal")
+
+    # ---- Stage 3: finance pretrain then freeze ----
+    _run_finance_then_freeze(log_suffix="fin_freeze", comment="fin-freeze")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- sanitize TensorBoard tags for trading metrics
- implement `fin_freeze` training strategy where finance-only weights are frozen before training with sentiment

## Testing
- `python -m py_compile train_multimodal.py dataset/MultiModalDataset.py trade.py logger.py`

------
https://chatgpt.com/codex/tasks/task_e_6873deff3c2c833395a9ba5f75241d31