### PR TITLE
Add ticker loop for multimodal training

### DIFF
--- a/config.py
+++ b/config.py
@@ -12,13 +12,23 @@ train_dir = os.path.join(working_dir, "data_finance", "train", "1d")
 test_dir = os.path.join(working_dir, "data_finance", "test", "1d")
 
 sentiment_ticker = "AAPL"
-sentiment_dir = os.path.join(working_dir, "data_sentim", "preprocessed", f"{sentiment_ticker}.csv")
+sentiment_ticker_list = [
+    "AAPL", "AXP", "BA", "CAT", "CSCO", "CVX", "DIS", "GS", "HD", "IBM",
+    "JPM", "MCD", "MMM", "MSFT", "NKE", "TRV", "UNH", "V", "VZ",
+]
+sentiment_dir = os.path.join(
+    working_dir,
+    "data_sentim",
+    "preprocessed",
+    f"{sentiment_ticker}.csv",
+)
 
 results_dir = os.path.join(working_dir, "results")
 record_dir = os.path.join(working_dir, "records")
 checkpoint_dir = os.path.join(working_dir, "checkpoints")
 
 num_parallel_trainings = 1
+num_topics = None  # infer from sentiment CSV
 
 model = CnnTa
 class_weights = [1, 2, 2]
@@ -26,7 +36,10 @@ class_weights = [1, 2, 2]
 train_years = [2017, 2022]
 test_years = [2023, 2024]
 
-indicators = ["RSI", "WIL", "WMA", "EMA", "SMA", "HMA", "TMA", "CCI", "CMO", "MCD", "PPO", "ROC", "CMF", "ADX", "PSA"]
+indicators = [
+    "RSI", "WIL", "WMA", "EMA", "SMA", "HMA", "TMA", "CCI", "CMO", "MCD",
+    "PPO", "ROC", "CMF", "ADX", "PSA",
+]
 
-run_name = r"DOW30_1h"
-run_name = f"{run_name}-{datetime.now().strftime('%m_%d_%H_%M')}"
+run_name_base = r"DOW30_1h"
+run_name = f"{run_name_base}-{datetime.now().strftime('%m_%d_%H_%M')}"

--- a/model/CnnTA.py
+++ b/model/CnnTA.py
@@ -12,6 +12,9 @@ class CnnTa(nn.Module):
 
         self.conv1 = nn.Conv2d(in_channels, 32, kernel_size=3, padding=1)
         self.conv2 = nn.Conv2d(32, 64, kernel_size=3, padding=1)
+        if apply_bn:
+            self.bn1 = nn.BatchNorm2d(32)
+            self.bn2 = nn.BatchNorm2d(64)
         self.pool = nn.MaxPool2d(kernel_size=2, stride=2)
 
         self.fc1 = nn.Linear(64 * pool_output_dim * pool_output_dim, 128)
@@ -22,7 +25,8 @@ class CnnTa(nn.Module):
 
         self.batch_norm_enabled = apply_bn
 
-    def forward(self, x):
+    def forward_features(self, x: torch.Tensor) -> torch.Tensor:
+        """Return embedding before the classification layer."""
         x = self.conv1(x)
         if self.batch_norm_enabled:
             x = self.bn1(x)
@@ -38,6 +42,10 @@ class CnnTa(nn.Module):
 
         x = torch.flatten(x, start_dim=1)
         x = F.gelu(self.fc1(x))
+        return x
+
+    def forward(self, x):
+        x = self.forward_features(x)
         x = self.dropout2(x)
         x = self.fc2(x)
 

--- a/model/CnnTaFusion.py
+++ b/model/CnnTaFusion.py
@@ -1,0 +1,34 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from .CnnTA import CnnTa
+
+class CnnTaFusion(nn.Module):
+    """CNN-TA backbone with an additional sentiment MLP.
+
+    The finance window is processed by :class:`CnnTa` using a single input
+    channel. Sentiment vectors are passed through a small MLP and the
+    resulting latent vector is concatenated with the CNN embedding after the
+    global-average-pooling stage (``forward_features`` of ``CnnTa``).
+    """
+
+    def __init__(self, num_topics: int, window_length: int = 15):
+        super().__init__()
+        self.cnn = CnnTa(in_channels=1, window_length=window_length)
+        self.sent_mlp = nn.Sequential(
+            nn.Flatten(),
+            nn.Linear(window_length * num_topics, 64),
+            nn.GELU(),
+            nn.Linear(64, 32),
+            nn.GELU(),
+        )
+        self.out = nn.Linear(128 + 32, 3)
+        self.dropout = nn.Dropout(0.5)
+
+    def forward(self, x_fin: torch.Tensor, x_sent: torch.Tensor) -> torch.Tensor:
+        fin_feat = self.cnn.forward_features(x_fin)
+        sent_feat = self.sent_mlp(x_sent)
+        feat = torch.cat([fin_feat, sent_feat], dim=1)
+        feat = self.dropout(feat)
+        return self.out(feat)
+

--- a/model/__init__.py
+++ b/model/__init__.py
@@ -1,1 +1,2 @@
 from model.CnnTA import CnnTa
+from model.CnnTaFusion import CnnTaFusion

--- a/train_multimodal.py
+++ b/train_multimodal.py
@@ -1,10 +1,12 @@
 import os, random, numpy as np, torch, config
+from datetime import datetime
 from pathlib import Path
 from tqdm import trange, tqdm
 from torch.utils.data import DataLoader
 from dataset.MultiModalDataset import MultiModalDataset
 from logger import TBLogger
 from trade import trading
+from model import CnnTaFusion
 
 # ───────── reproducibility ─────────
 torch.manual_seed(42);
@@ -209,6 +211,81 @@ def _run_finance_then_freeze(log_suffix: str, comment: str) -> None:
     logger.close()
 
 
+def _run_fusion_vector(log_suffix: str, comment: str) -> None:
+    """Train a model that fuses finance features with a sentiment MLP."""
+
+    finance_train_dir = list(Path(config.train_dir).glob(config.sentiment_ticker + "*.csv"))[0]
+    finance_test_dir = list(Path(config.test_dir).glob(config.sentiment_ticker + "*.csv"))[0]
+
+    train_ds = MultiModalDataset(
+        str(finance_train_dir),
+        config.sentiment_dir,
+        config.indicators,
+        include_sentiment=True,
+        num_topics=config.num_topics,
+    )
+    train_ld = DataLoader(
+        train_ds, batch_size=config.batch_size, shuffle=True, pin_memory=True, drop_last=True
+    )
+
+    test_ds = MultiModalDataset(
+        str(finance_test_dir),
+        config.sentiment_dir,
+        config.indicators,
+        include_sentiment=True,
+        num_topics=config.num_topics,
+    )
+    test_ld = DataLoader(test_ds, batch_size=config.batch_size, shuffle=False, pin_memory=True)
+
+    model = CnnTaFusion(num_topics=train_ds.num_topics).to(device)
+    opt = torch.optim.Adam(model.parameters(), lr=config.learning_rate)
+    crit = torch.nn.CrossEntropyLoss(
+        weight=torch.tensor(config.class_weights, device=device)
+    )
+
+    run_name = f"{config.run_name}_{log_suffix}"
+    logger = TBLogger(config.record_dir, run_name, comment=comment)
+
+    for epoch in trange(config.max_epochs, desc="Fusion"):
+        model.train(); ep_loss, p_all, y_all = 0.0, [], []
+        for _, _, imgs, lbls in tqdm(train_ld, desc="Train", leave=False):
+            fin = imgs[:, 0:1].to(device, non_blocking=True)
+            sent = imgs[:, 1].to(device, non_blocking=True)
+            lbls = lbls.to(device, non_blocking=True)
+
+            opt.zero_grad(set_to_none=True)
+            outs = model(fin, sent)
+            loss = crit(outs, lbls)
+            loss.backward()
+            opt.step()
+
+            ep_loss += loss.item()
+            p_all.extend(torch.argmax(outs, 1).cpu().tolist())
+            y_all.extend(torch.argmax(lbls, 1).cpu().tolist())
+
+        logger.log_epoch("train", epoch, ep_loss / len(train_ld), np.array(y_all), np.array(p_all))
+
+        # ---- eval ----
+        model.eval(); tot_loss, batches = 0.0, 0; p_all, y_all = [], []; by_symbol = {}
+        with torch.no_grad():
+            for ts, closes, imgs, lbls in tqdm(test_ld, desc="Eval", leave=False):
+                fin = imgs[:, 0:1].to(device)
+                sent = imgs[:, 1].to(device)
+                lbls = lbls.to(device)
+                outs = model(fin, sent)
+                tot_loss += crit(outs, lbls).item(); batches += 1
+                preds = torch.argmax(outs, 1).cpu().tolist(); labs = torch.argmax(lbls, 1).cpu().tolist()
+                p_all.extend(preds); y_all.extend(labs)
+                bucket = by_symbol.setdefault(config.sentiment_ticker, {"ts": [], "cl": [], "pr": []})
+                bucket["ts"].extend(ts.cpu().tolist()); bucket["cl"].extend(closes.cpu().tolist()); bucket["pr"].extend(preds)
+
+        logger.log_epoch("eval", epoch, tot_loss / batches, np.array(y_all), np.array(p_all))
+        trade_res = [trading(v["ts"], v["cl"], v["pr"])[0] for v in by_symbol.values()]
+        logger.log_trading(epoch, trade_res)
+
+    logger.close()
+
+
 def train():
     # ---- Stage 1: finance-only training ----
     _run_training(in_channels=1, include_sentiment=False,
@@ -221,7 +298,21 @@ def train():
     # ---- Stage 3: finance pretrain then freeze ----
     _run_finance_then_freeze(log_suffix="fin_freeze", comment="fin-freeze")
 
+    # ---- Stage 4: fusion with sentiment MLP ----
+    _run_fusion_vector(log_suffix="fusion_vec", comment="fusion-vector")
+
 
 if __name__ == "__main__":
-    train()
+    tickers = getattr(config, "sentiment_ticker_list", [config.sentiment_ticker])
+    base_name = getattr(config, "run_name_base", config.run_name)
+    for t in tickers:
+        config.sentiment_ticker = t
+        config.sentiment_dir = os.path.join(
+            config.working_dir,
+            "data_sentim",
+            "preprocessed",
+            f"{t}.csv",
+        )
+        config.run_name = f"{base_name}_{t}-{datetime.now().strftime('%m_%d_%H_%M')}"
+        train()
     print("✓ Training complete.")


### PR DESCRIPTION
## Summary
- support running experiments for multiple sentiment tickers
- set up `run_name_base` and ticker list in config
- iterate through all tickers in `train_multimodal.py`

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6874ed014cc08333a54342fc6303024c