### PR TITLE
Add attention-based training script

### DIFF
--- a/model/AttnTA.py
+++ b/model/AttnTA.py
@@ -1,0 +1,47 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+class AttnTa(nn.Module):
+    """Simple transformer-based model for 15x15 finance windows.
+
+    Each time step of the input window is treated as a token and processed
+    by a small Transformer encoder. A learnable classification token is used
+    to pool sequence information for classification.
+    """
+
+    def __init__(self, seq_len: int = 15, in_channels: int = 1,
+                 d_model: int = 64, num_heads: int = 8, num_layers: int = 2):
+        super().__init__()
+        self.seq_len = seq_len
+        self.in_dim = in_channels * seq_len  # 15 features per step * channels
+
+        self.embed = nn.Linear(self.in_dim, d_model)
+        self.cls_token = nn.Parameter(torch.zeros(1, 1, d_model))
+        self.pos_embed = nn.Parameter(torch.zeros(1, seq_len + 1, d_model))
+
+        encoder_layer = nn.TransformerEncoderLayer(
+            d_model, num_heads, dim_feedforward=d_model * 4,
+            batch_first=True
+        )
+        self.transformer = nn.TransformerEncoder(encoder_layer, num_layers)
+        self.dropout = nn.Dropout(0.5)
+        self.fc = nn.Linear(d_model, 3)
+
+    def forward_features(self, x: torch.Tensor) -> torch.Tensor:
+        b = x.size(0)
+        # x : (B, C, 15, 15) -> (B, 15, C*15)
+        x = x.permute(0, 2, 1, 3).reshape(b, self.seq_len, -1)
+        x = self.embed(x)
+        cls = self.cls_token.expand(b, -1, -1)
+        x = torch.cat([cls, x], dim=1)
+        x = x + self.pos_embed[:, : self.seq_len + 1]
+        x = self.transformer(x)
+        return x[:, 0]
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        feat = self.forward_features(x)
+        feat = self.dropout(feat)
+        return self.fc(feat)
+

--- a/model/__init__.py
+++ b/model/__init__.py
@@ -1,2 +1,3 @@
 from model.CnnTA import CnnTa
 from model.CnnTaFusion import CnnTaFusion
+from model.AttnTA import AttnTa

--- a/train_attention.py
+++ b/train_attention.py
@@ -1,0 +1,119 @@
+import os
+import random
+import numpy as np
+import torch
+import config
+from datetime import datetime
+from pathlib import Path
+from tqdm import trange, tqdm
+from torch.utils.data import DataLoader
+
+from dataset.MultiModalDataset import MultiModalDataset
+from model.AttnTA import AttnTa
+from logger import TBLogger
+from trade import trading
+
+# Reproducibility
+torch.manual_seed(42)
+np.random.seed(42)
+random.seed(42)
+torch.backends.cudnn.deterministic = False
+torch.backends.cudnn.benchmark = True
+
+device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+
+def _run_training(in_channels: int, include_sentiment: bool, suffix: str) -> None:
+    model = AttnTa(in_channels=in_channels).to(device)
+    opt = torch.optim.Adam(model.parameters(), lr=config.learning_rate)
+    crit = torch.nn.CrossEntropyLoss(
+        weight=torch.tensor(config.class_weights, device=device)
+    )
+
+    finance_train = list(Path(config.train_dir).glob(config.sentiment_ticker + "*.csv"))[0]
+    finance_test = list(Path(config.test_dir).glob(config.sentiment_ticker + "*.csv"))[0]
+
+    train_ds = MultiModalDataset(
+        str(finance_train),
+        config.sentiment_dir,
+        config.indicators,
+        include_sentiment=include_sentiment,
+    )
+    train_ld = DataLoader(train_ds, batch_size=config.batch_size, shuffle=True,
+                          pin_memory=True, drop_last=True)
+
+    test_ds = MultiModalDataset(
+        str(finance_test),
+        config.sentiment_dir,
+        config.indicators,
+        include_sentiment=include_sentiment,
+    )
+    test_ld = DataLoader(test_ds, batch_size=config.batch_size, shuffle=False,
+                         pin_memory=True)
+
+    run_name = f"{config.run_name}_{suffix}"
+    logger = TBLogger(config.record_dir, run_name, comment="attention")
+
+    for epoch in trange(config.max_epochs, desc="Epochs"):
+        # ----- train -----
+        model.train(); ep_loss, p_all, y_all = 0.0, [], []
+        for _, _, imgs, lbls in tqdm(train_ld, desc="Train", leave=False):
+            imgs = imgs.to(device, non_blocking=True)
+            lbls = lbls.to(device, non_blocking=True)
+            opt.zero_grad(set_to_none=True)
+            outs = model(imgs)
+            loss = crit(outs, lbls)
+            loss.backward()
+            opt.step()
+
+            ep_loss += loss.item()
+            p_all.extend(torch.argmax(outs, 1).cpu().tolist())
+            y_all.extend(torch.argmax(lbls, 1).cpu().tolist())
+        logger.log_epoch("train", epoch, ep_loss / len(train_ld),
+                         np.array(y_all), np.array(p_all))
+
+        # ----- eval -----
+        model.eval(); tot_loss, batches = 0.0, 0
+        p_all, y_all = [], []; by_symbol = {}
+        with torch.no_grad():
+            for ts, closes, imgs, lbls in tqdm(test_ld, desc="Eval", leave=False):
+                imgs = imgs.to(device)
+                lbls = lbls.to(device)
+                outs = model(imgs)
+                tot_loss += crit(outs, lbls).item(); batches += 1
+
+                preds = torch.argmax(outs, 1).cpu().tolist()
+                labs = torch.argmax(lbls, 1).cpu().tolist()
+                p_all.extend(preds); y_all.extend(labs)
+                bucket = by_symbol.setdefault(config.sentiment_ticker,
+                                               {"ts": [], "cl": [], "pr": []})
+                bucket["ts"].extend(ts.cpu().tolist())
+                bucket["cl"].extend(closes.cpu().tolist())
+                bucket["pr"].extend(preds)
+        logger.log_epoch("eval", epoch, tot_loss / batches,
+                         np.array(y_all), np.array(p_all))
+        trade_res = [trading(v["ts"], v["cl"], v["pr"])[0]
+                     for v in by_symbol.values()]
+        logger.log_trading(epoch, trade_res)
+    logger.close()
+
+
+def train():
+    _run_training(in_channels=1, include_sentiment=False, suffix="fin")
+    _run_training(in_channels=2, include_sentiment=True, suffix="multi")
+
+
+if __name__ == "__main__":
+    tickers = getattr(config, "sentiment_ticker_list", [config.sentiment_ticker])
+    base_name = getattr(config, "run_name_base", config.run_name)
+    for t in tickers:
+        config.sentiment_ticker = t
+        config.sentiment_dir = os.path.join(
+            config.working_dir,
+            "data_sentim",
+            "preprocessed",
+            f"{t}.csv",
+        )
+        config.run_name = f"{base_name}_{t}-{datetime.now().strftime('%m_%d_%H_%M')}"
+        train()
+    print("✓ Training complete.")


### PR DESCRIPTION
## Summary
- implement `AttnTa` transformer model
- export `AttnTa` from model package
- add `train_attention.py` for finance-only and multimodal training using `AttnTa`

## Testing
- `python -m py_compile model/AttnTA.py train_attention.py`

------
https://chatgpt.com/codex/tasks/task_e_687e61fd44448333bf539c3d96e328cc