### PR TITLE
Generalize transformer token embedding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# Sentim-TA
+
+This repository contains experiments with CNN and Transformer models for technical indicator based trading.
+
+## Transformer input format
+
+The `AttnTa` model processes a sequence of daily indicator vectors. Each day provides a vector of 15 technical indicators (optionally for multiple channels such as sentiment). These vectors are first mapped into the model hidden dimension using a small linear layer and then positional embeddings are added before passing the sequence to a Transformer encoder.
+
+Refer to `model/AttnTA.py` for implementation details.

--- a/train_attention.py
+++ b/train_attention.py
@@ -24,7 +24,10 @@ device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
 
 def _run_training(in_channels: int, include_sentiment: bool, suffix: str) -> None:
-    model = AttnTa(in_channels=in_channels).to(device)
+    model = AttnTa(
+        in_channels=in_channels,
+        num_features=len(config.indicators)
+    ).to(device)
     opt = torch.optim.Adam(model.parameters(), lr=config.learning_rate)
     crit = torch.nn.CrossEntropyLoss(
         weight=torch.tensor(config.class_weights, device=device)


### PR DESCRIPTION
## Summary
- parameterize the AttnTa transformer over the number of indicators
- update training script to pass indicator count
- add a short README describing the transformer input format

## Testing
- `python -m py_compile train_attention.py model/AttnTA.py`

------
https://chatgpt.com/codex/tasks/task_e_687fe119d61483338adcd2d934029c7a